### PR TITLE
feat: added superuser creation & password reset endpoints

### DIFF
--- a/Jardipotes/settings.py
+++ b/Jardipotes/settings.py
@@ -43,7 +43,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'accounts',
     'rest_framework',
-    'rest_framework.authtoken'
+    'rest_framework.authtoken',
+    'django_rest_passwordreset'
 ]
 
 AUTH_USER_MODEL = 'accounts.User'
@@ -72,7 +73,7 @@ ROOT_URLCONF = 'Jardipotes.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -86,7 +87,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'Jardipotes.wsgi.application'
-
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases

--- a/Jardipotes/urls.py
+++ b/Jardipotes/urls.py
@@ -4,8 +4,16 @@ from django.conf import settings
 from django.conf.urls.static import static
 
 
+""" 
+POST ${API_URL}/ - request a reset password token by using the email parameter
+POST ${API_URL}/confirm/ - using a valid token, the users password is set to the provided password
+POST ${API_URL}/validate_token/ - will return a 200 if a given token is valid
+"""
+
 urlpatterns = [
     re_path('admin/', admin.site.urls),
     re_path('api/users/', include('accounts.urls')),
+
+
 
 ]

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -18,6 +18,17 @@ class UserManager(BaseUserManager):
         user.save(using=self._db)
         return user
 
+    def create_superuser(self, email, password, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+        extra_fields.setdefault('is_active', True)
+
+        if extra_fields.get('is_staff') is not True:
+            raise ValueError(_('Superuser must have is_staff=True.'))
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError(_('Superuser must have is_superuser=True.'))
+        return self.create_user(email, password, **extra_fields)
+
 
 class User(AbstractUser):
     pass

--- a/accounts/templates/user_reset_password.html
+++ b/accounts/templates/user_reset_password.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Il est où mon code secret ?</title>
+</head>
+<body>
+    <div>
+        <h2>Salut toi,</h2>
+
+            <p>Tu as oublié ton code secret pour rentrer chez JardiPotes ? 
+            Voilà tu peux le réinitialiser ici ! </p>
+    </div>
+</body>
+</html>

--- a/accounts/templates/user_reset_password.txt
+++ b/accounts/templates/user_reset_password.txt
@@ -1,0 +1,4 @@
+Salut toi,
+
+Tu as oublié ton code secret pour rentrer chez JardiPotes ? 
+Voilà tu peux le réinitialiser ici ! 

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, include
 from . import views
 from rest_framework.authtoken.views import obtain_auth_token
 
@@ -15,5 +15,8 @@ urlpatterns = [
     path('update_user/<str:pk>/', views.update_user, name="update"),
     path('delete/<str:pk>/', views.delete_user, name="delete"),
     path('auth/', obtain_auth_token),
+    path('password_reset/',
+         include('django_rest_passwordreset.urls', namespace='password_reset')),
+
 
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -116,7 +116,7 @@ def password_reset_token_created(sender, instance, reset_password_token, *args, 
     msg = EmailMultiAlternatives(
         # title:
         "Password Reset for {title}".format(
-            title="Rénititier le code secret pour JardiPotes"),
+            title="Réinitialiser le code secret pour JardiPotes"),
         # message:
         email_plaintext_message,
         # from:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -8,6 +8,11 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework import status
 from rest_framework.authtoken.models import Token
+from django.core.mail import EmailMultiAlternatives
+from django.dispatch import receiver
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django_rest_passwordreset.signals import reset_password_token_created
 import json
 
 """Create a user
@@ -71,6 +76,56 @@ def update_user(request, pk):
     if serializer.is_valid():
         serializer.save()
     return Response(serializer.data)
+
+
+""" password reset method """
+
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+@receiver(reset_password_token_created)
+def password_reset_token_created(sender, instance, reset_password_token, *args, **kwargs):
+    """
+    Handles password reset tokens
+    When a token is created, an e-mail needs to be sent to the user
+    :param sender: View Class that sent the signal
+    :param instance: View Instance that sent the signal
+    :param reset_password_token: Token Model Object
+    :param args:
+    :param kwargs:
+    :return:
+    """
+    # send an e-mail to the user
+    # reset password confirmation url looks like this: host/api/users/password_reset/?token=TOKEN
+    context = {
+        'current_user': reset_password_token.user,
+        'first_name': reset_password_token.user.first_name,
+        'email': reset_password_token.user.email,
+        'reset_password_url': "{}?token={}".format(
+            instance.request.build_absolute_uri(
+                reverse('password_reset:reset-password-confirm')),
+            reset_password_token.key)
+    }
+
+    # render email text
+    email_html_message = render_to_string(
+        'user_reset_password.html', context)
+    email_plaintext_message = render_to_string(
+        'user_reset_password.txt', context)
+
+    msg = EmailMultiAlternatives(
+        # title:
+        "Password Reset for {title}".format(
+            title="Rénititier le code secret pour JardiPotes"),
+        # message:
+        email_plaintext_message,
+        # from:
+        "sadefryt@gmail.com",
+        # to:
+        [reset_password_token.user.email]
+    )
+    msg.attach_alternative(email_html_message, "text/html")
+    msg.send()
 
 
 @api_view(['DELETE'])

--- a/poetry.lock
+++ b/poetry.lock
@@ -109,6 +109,14 @@ confusable-homoglyphs = ">=3.0,<4.0"
 Django = ">=3.2"
 
 [[package]]
+name = "django-rest-passwordreset"
+version = "1.3.0"
+description = "An extension of django rest framework, providing a configurable password reset strategy"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "djangorestframework"
 version = "3.14.0"
 description = "Web APIs for Django, made easy."
@@ -294,7 +302,7 @@ python-versions = ">=2"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "ad173a787a442645e7372e9606115008a660ef74ab89e38fdc520442053a3b48"
+content-hash = "8b3d0eba46504878df1e91e1612758e69a7d7bfc8464ad235831a44034ceda7c"
 
 [metadata.files]
 asgiref = [
@@ -346,6 +354,10 @@ django-environ = [
 django-registration = [
     {file = "django-registration-3.3.tar.gz", hash = "sha256:884a4cc9ec87b9f1c0ceb6b6c4b7ba491c1877997a3cd29cc923697dac785eb8"},
     {file = "django_registration-3.3-py3-none-any.whl", hash = "sha256:dfa176f594fb465c93495caa55686be723a15829769511383e25172d2efbd0e6"},
+]
+django-rest-passwordreset = [
+    {file = "django-rest-passwordreset-1.3.0.tar.gz", hash = "sha256:0d76eb8d0be9636f4404fd35e8a0842c968effeac1d141c55a45aef1ebce54c7"},
+    {file = "django_rest_passwordreset-1.3.0-py3-none-any.whl", hash = "sha256:f888fcb589c46e2f86f9686751de4cc1350c519aa3b120b993b1d675fd96fad6"},
 ]
 djangorestframework = [
     {file = "djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pytest = "^7.1.3"
 django-environ = "^0.9.0"
 djangorestframework = "^3.14.0"
 django-registration = "^3.3"
+django-rest-passwordreset = "^1.3.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
# ℹ️ Context
[RELATED TICKET](https://github.com/JardiPotes/back-garden/issues/30)
[RELATED TICKET](https://github.com/JardiPotes/back-garden/issues/3)

Fixed SuperUser creation and implemented the password reset method. 
To reset the password, the user will receive an email with a valid token. The token for now doesn't have any expiration date. It could be set on `settings.py`.

The email template is in the `templates` folder, we might want to write something more friendly.

Unit tests will be added later on.

The library used here: https://github.com/anexia-it/django-rest-passwordreset

## ❓ Type of change
Please delete options that are not relevant.

* ✨ New feature (non-breaking change which adds functionality)
* 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
