### PR TITLE
fix: changed garden crud to viewset

### DIFF
--- a/Jardipotes/urls.py
+++ b/Jardipotes/urls.py
@@ -1,5 +1,15 @@
 from django.contrib import admin
-from django.urls import include, re_path
+from django.urls import re_path, include, path
+from django.conf import settings
+from django.conf.urls.static import static
+from rest_framework import routers
+from accounts.views import GardenViewset
+
+# Ici nous créons notre routeur
+router = routers.SimpleRouter()
+# Puis lui déclarons une url basée sur le mot clé ‘category’ et notre view
+# afin que l’url générée soit celle que nous souhaitons ‘/api/category/’
+router.register('gardens', GardenViewset, basename='gardens')
 
 """
 POST ${API_URL}/ - request a reset password token by using the email parameter
@@ -8,6 +18,7 @@ POST ${API_URL}/validate_token/ - will return a 200 if a given token is valid
 """
 
 urlpatterns = [
-    re_path("admin/", admin.site.urls),
-    re_path("api/", include("accounts.urls")),
+    path('api/', include(router.urls)),
+    re_path('admin/', admin.site.urls),
+    re_path('/', include('accounts.urls')),
 ]

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,4 +1,4 @@
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -27,7 +27,7 @@ class CreateUserTests(APITestCase):
 class CreateGardenTests(APITestCase):
     def test_create_garden(self):
 
-        url = reverse("create_garden")
+        url = reverse_lazy("gardens-list")
         user = UserFactory.create_user()
         data = GardenFactory.create_garden_dict(userId=user.id, title="au vert")
 

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -20,11 +20,5 @@ urlpatterns = [
     path(
         "password_reset/",
         include("django_rest_passwordreset.urls", namespace="password_reset"),
-    ),
-    # gardens
-    # path('gardens/', include(router.urls)),
-    # path('garden/<str:pk>/', views.get_garden_detail),
-    # path('create_garden/', views.create_garden, name="create_garden"),
-    # path('update_garden/<str:pk>/', views.update_garden, name="update_garden"),
-    # path('delete_garden/<str:pk>/', views.delete_garden, name="delete_garden")
+    )
 ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -22,9 +22,9 @@ urlpatterns = [
         include("django_rest_passwordreset.urls", namespace="password_reset"),
     ),
     # gardens
-    path("gardens/", views.list_gardens),
-    path("garden/<str:pk>/", views.get_garden_detail),
-    path("create_garden/", views.create_garden, name="create_garden"),
-    path("update_garden/<str:pk>/", views.update_garden, name="update_garden"),
-    path("delete_garden/<str:pk>/", views.delete_garden, name="delete_garden"),
+    # path('gardens/', include(router.urls)),
+    # path('garden/<str:pk>/', views.get_garden_detail),
+    # path('create_garden/', views.create_garden, name="create_garden"),
+    # path('update_garden/<str:pk>/', views.update_garden, name="update_garden"),
+    # path('delete_garden/<str:pk>/', views.delete_garden, name="delete_garden")
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -219,77 +219,13 @@ class GardenViewset(ModelViewSet):
 
     def get_queryset(self):
         queryset = Garden.objects.all()
+        data = self.request.data
 
-        userId = self.request.GET.get('user_id')
         mostRecent = self.request.GET.get('recent')
-        if userId is not None:
-            queryset = queryset.filter(userId=userId)
+        if 'userId' in data:
+            queryset = queryset.filter(userId_id=data["userId"])
+        if 'zipcode' in data:
+            queryset = queryset.filter(zipcode=data["zipcode"])
         if mostRecent is not None:
             queryset = queryset.order_by('created_at')[:10][::-1]
         return queryset
-
-
-# @api_view(['GET'])
-# @permission_classes([AllowAny])
-# def list_all_gardens(request):
-#     gardens = Garden.objects.all().order_by('created_at')
-#     serializer = GardenSerializer(gardens, many=True)
-
-#     return Response(serializer.data)
-
-
-""" Get 10 last gardens """
-
-
-# @api_view(['GET'])
-# @permission_classes([AllowAny])
-# def list_gardens(request):
-#     gardens = Garden.objects.all().order_by('created_at')[:10][::-1]
-#     serializer = GardenSerializer(gardens, many=True)
-#     return Response(serializer.data)
-
-
-""" Get one garden """
-
-# @api_view(['GET'])
-# @permission_classes([AllowAny])
-# def get_garden_detail(request, pk):
-#     garden = Garden.objects.get(id=pk)
-#     serializer = GardenSerializer(garden, many=False)
-#     return Response(serializer.data)
-
-""" Create one garden """
-
-# @api_view(['POST'])
-# @permission_classes([AllowAny])
-# def create_garden(request):
-#     serializer = GardenSerializer(data=request.data)
-#     if serializer.is_valid():
-#         garden = serializer.save()
-#         garden.save()
-
-#         return Response(serializer.data, status=status.HTTP_201_CREATED)
-#     else:
-#         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-""" Delete one garden """
-
-# @api_view(['DELETE'])
-# @permission_classes([IsAuthenticated])
-# def delete_garden(request, pk):
-#     garden = Garden.objects.get(id=pk)
-#     garden.delete()
-
-#     return Response('Deleted')
-
-""" Update one garden """
-
-# @api_view(['PATCH'])
-# @permission_classes([IsAuthenticated])
-# def update_garden(request, pk):
-#     garden = Garden.objects.get(id=pk)
-#     serializer = GardenSerializer(instance=garden, data=request.data)
-#     if serializer.is_valid():
-#         serializer.save()
-#     return Response(serializer.data)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -3,6 +3,14 @@ import json
 from django.contrib.auth import login
 from django.contrib.auth.hashers import check_password
 from django.core.exceptions import ValidationError
+from .models import User, Garden
+from .serializers import UserSerializer, GardenSerializer
+from rest_framework.response import Response
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from django.core.mail import EmailMultiAlternatives
 from django.dispatch import receiver
 from django.template.loader import render_to_string
@@ -16,6 +24,7 @@ from rest_framework.response import Response
 
 from .models import Garden, User
 from .serializers import GardenSerializer, UserSerializer
+
 
 """Create a user
 
@@ -199,67 +208,88 @@ def user_logout(request):
 
 """ Garden methods """
 
+""" GardenViewset includes GET/POST/PUT/DELETE methods with or without params """
+
+
+class GardenViewset(ModelViewSet):
+
+    serializer_class = GardenSerializer
+    # change to isAuthenticated when needed
+    permission_classes = [AllowAny]
+
+    def get_queryset(self):
+        queryset = Garden.objects.all()
+
+        userId = self.request.GET.get('user_id')
+        mostRecent = self.request.GET.get('recent')
+        if userId is not None:
+            queryset = queryset.filter(userId=userId)
+        if mostRecent is not None:
+            queryset = queryset.order_by('created_at')[:10][::-1]
+        return queryset
+
+
+# @api_view(['GET'])
+# @permission_classes([AllowAny])
+# def list_all_gardens(request):
+#     gardens = Garden.objects.all().order_by('created_at')
+#     serializer = GardenSerializer(gardens, many=True)
+
+#     return Response(serializer.data)
+
+
 """ Get 10 last gardens """
 
 
-@api_view(["GET"])
-@permission_classes([AllowAny])
-def list_gardens(request):
-    gardens = Garden.objects.all().order_by("created_at")[:10][::-1]
-    serializer = GardenSerializer(gardens, many=True)
-
-    return Response(serializer.data)
+# @api_view(['GET'])
+# @permission_classes([AllowAny])
+# def list_gardens(request):
+#     gardens = Garden.objects.all().order_by('created_at')[:10][::-1]
+#     serializer = GardenSerializer(gardens, many=True)
+#     return Response(serializer.data)
 
 
 """ Get one garden """
 
-
-@api_view(["GET"])
-@permission_classes([AllowAny])
-def get_garden_detail(request, pk):
-    garden = Garden.objects.get(id=pk)
-    serializer = GardenSerializer(garden, many=False)
-    return Response(serializer.data)
-
+# @api_view(['GET'])
+# @permission_classes([AllowAny])
+# def get_garden_detail(request, pk):
+#     garden = Garden.objects.get(id=pk)
+#     serializer = GardenSerializer(garden, many=False)
+#     return Response(serializer.data)
 
 """ Create one garden """
 
+# @api_view(['POST'])
+# @permission_classes([AllowAny])
+# def create_garden(request):
+#     serializer = GardenSerializer(data=request.data)
+#     if serializer.is_valid():
+#         garden = serializer.save()
+#         garden.save()
 
-@api_view(["POST"])
-@permission_classes([AllowAny])
-def create_garden(request):
-
-    serializer = GardenSerializer(data=request.data)
-    if serializer.is_valid():
-        garden = serializer.save()
-        garden.save()
-
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
-    else:
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+#         return Response(serializer.data, status=status.HTTP_201_CREATED)
+#     else:
+#         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 """ Delete one garden """
 
+# @api_view(['DELETE'])
+# @permission_classes([IsAuthenticated])
+# def delete_garden(request, pk):
+#     garden = Garden.objects.get(id=pk)
+#     garden.delete()
 
-@api_view(["DELETE"])
-@permission_classes([IsAuthenticated])
-def delete_garden(request, pk):
-    garden = Garden.objects.get(id=pk)
-    garden.delete()
-
-    return Response("Deleted")
-
+#     return Response('Deleted')
 
 """ Update one garden """
 
-
-@api_view(["PATCH"])
-@permission_classes([IsAuthenticated])
-def update_garden(request, pk):
-    garden = Garden.objects.get(id=pk)
-    serializer = GardenSerializer(instance=garden, data=request.data)
-
-    if serializer.is_valid():
-        serializer.save()
-    return Response(serializer.data)
+# @api_view(['PATCH'])
+# @permission_classes([IsAuthenticated])
+# def update_garden(request, pk):
+#     garden = Garden.objects.get(id=pk)
+#     serializer = GardenSerializer(instance=garden, data=request.data)
+#     if serializer.is_valid():
+#         serializer.save()
+#     return Response(serializer.data)


### PR DESCRIPTION
# ℹ️ Context

Using Django-rest-framework's ModelViewset and router to have all crud operations on garden on a single viewset and a single url 

## ❓ Type of change
Please delete options that are not relevant.

* 🐛 Bug fix (non-breaking change which fixes an issue)
* 📜 This change requires a documentation update

