### PR TITLE
feat: implement permissions for gardens [73]

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,7 +1,5 @@
-from django.contrib.auth import (authenticate, get_user_model,
-                                 password_validation)
+from django.contrib.auth import get_user_model, password_validation
 from django.contrib.auth.models import BaseUserManager
-from django.core.validators import ValidationError
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -2,12 +2,10 @@ import json
 
 from rest_framework import status
 from rest_framework.authtoken.models import Token
-from rest_framework.test import (APIClient, APIRequestFactory, APITestCase,
-                                 RequestsClient, force_authenticate)
+from rest_framework.test import APITestCase
 
 from .factory import UserFactory
 from .models import User
-from .views import AuthViewSet
 
 
 class TestRegisterUser(APITestCase):
@@ -116,9 +114,9 @@ class TestUserLogin(APITestCase):
 class TestUserLogout(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user("john@snow.com", "johnpassword")
-        self.client.force_authenticate(self.user)
 
     def test_can_logout(self):
+        self.client.force_authenticate(user=self.user)
         response = self.client.post("/api/auth/logout")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -176,5 +174,4 @@ class TestUpdateUser(APITestCase):
         response = self.client.put(f"/api/users/{self.user.id}", data, format="json")
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    # self.assertEqual(json_response["bio"], "barfoo")
+        self.assertEqual(json_response["bio"], "barfoo")

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,16 +1,13 @@
 from django.contrib.auth import get_user_model, login, logout
 from django.core.exceptions import ImproperlyConfigured
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from rest_framework import status, viewsets
-from rest_framework.authtoken.models import Token
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.validators import ValidationError
-from rest_framework.viewsets import ModelViewSet
 
 from . import serializers
-from .serializers import AuthUserSerializer, UserUpdateSerializer
 from .utils import create_user_account, get_and_authenticate_user
 
 User = get_user_model()
@@ -96,7 +93,6 @@ class AuthViewSet(viewsets.GenericViewSet):
         return super().get_serializer_class()
 
 
-# TODO Implement update user function
 class UserViewSet(viewsets.ViewSet):
     permission_classes = [
         AllowAny,

--- a/apis/permissions.py
+++ b/apis/permissions.py
@@ -1,0 +1,8 @@
+from rest_framework import permissions
+
+
+class IsGardenOwnerPermission(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return obj.user_id.id == request.user.id

--- a/apis/serializers.py
+++ b/apis/serializers.py
@@ -1,4 +1,3 @@
-from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
 from .models import Garden, Photo

--- a/apis/views.py
+++ b/apis/views.py
@@ -1,7 +1,8 @@
-from rest_framework import status
 from rest_framework.parsers import FormParser, MultiPartParser
-from rest_framework.permissions import AllowAny, IsAuthenticated
-from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.viewsets import ModelViewSet
+
+from .permissions import IsGardenOwnerPermission
 
 from .models import Garden, Photo
 from .serializers import GardenSerializer, PhotoSerializer
@@ -14,37 +15,32 @@ from .serializers import GardenSerializer, PhotoSerializer
 class GardenViewset(ModelViewSet):
 
     serializer_class = GardenSerializer
-    # change to isAuthenticated when needed
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticatedOrReadOnly, IsGardenOwnerPermission]
+
+    queryset = Garden.objects.all()
+
+    def get_permissions(self):
+        if self.action == "update" or self.action == "partial_update":
+            permission_classes = [IsGardenOwnerPermission]
+        else:
+            permission_classes = [IsAuthenticatedOrReadOnly]
+        res = [permission() for permission in permission_classes]
+        return res
 
     def get_queryset(self):
-        queryset = Garden.objects.all()
-
+        queryset = self.queryset
         user_id = self.request.query_params.get("user_id")
         zipcode = self.request.query_params.get("zipcode")
         if user_id is not None:
-            queryset = queryset.filter(user_id=user_id)
+            queryset = self.queryset.filter(user_id=user_id)
         if zipcode is not None:
-            queryset = queryset.filter(zipcode=zipcode)
+            queryset = self.queryset.filter(zipcode=zipcode)
         return queryset
-
-
-# TODO check the pagination here
-#   data = self.request.data
-# mostRecent = self.request.GET.get('recent')
-# if 'user_id' in data:
-#     queryset = queryset.filter(user_id=data["user_id"])
-# if 'zipcode' in data:
-#     queryset = queryset.filter(zipcode=data["zipcode"])
-# if mostRecent is not None:
-#     queryset = queryset.order_by('created_at')[:10][::-1]
-# return queryset
 
 
 class PhotoViewset(ModelViewSet):
     serializer_class = PhotoSerializer
-    # change to IsAuthenticated
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticatedOrReadOnly]
     parser_classes = (MultiPartParser, FormParser)
     queryset = Photo.objects.all()
 


### PR DESCRIPTION
# ℹ️ Context
[73](https://github.com/JardiPotes/back-garden/issues/73)

Done:
- Implement `IsGardenOwnerPermission` to protect the `update` route.
-  Protected the `update` route. (`PUT` & `PATCH`)
- Tests implemented

TO DO:
- [ ] Protect the `DELETE` endpoint for only `admin roles` and the `owner of the garden`
- [ ] Implement the same thing for PHOTOS

## ❓ Type of change

* ✨ New feature (non-breaking change which adds functionality)
