### PR TITLE
feat: add user_info in response when user logged in

### DIFF
--- a/accounts/factory.py
+++ b/accounts/factory.py
@@ -10,7 +10,6 @@ class UserFactory:
         nickname="Teston",
         email: str = None,
         password: str = "s3cr3tP@SSW0RD",
-        has_garden: bool = False,
         experience: int = 1,
         bio: str = "Cives, nos omnes amare debemus hortos nostros. Partire hortos nostros cum ceteris est bonum, quia ex hortis nostris crescere possunt fructus et herbas saporae et salubritatis. Sic, si tu habes hortum magnum et aliis non est hortus, tu debes cum illis partire hortum tuum. Si autem tu non habes hortum, petere hortum ad colendum ab amico potes. Laeti erimus omnes si hortos nostros inter nos partiamur!",
         profile_image="",

--- a/accounts/migrations/0005_alter_user_profile_image.py
+++ b/accounts/migrations/0005_alter_user_profile_image.py
@@ -6,13 +6,15 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('accounts', '0004_alter_user_profile_image'),
+        ("accounts", "0004_alter_user_profile_image"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='user',
-            name='profile_image',
-            field=models.ImageField(default='default_profile_image.png', upload_to='accounts/images'),
+            model_name="user",
+            name="profile_image",
+            field=models.ImageField(
+                default="default_profile_image.png", upload_to="accounts/images"
+            ),
         ),
     ]

--- a/accounts/migrations/0006_alter_user_profile_image.py
+++ b/accounts/migrations/0006_alter_user_profile_image.py
@@ -6,13 +6,16 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('accounts', '0005_alter_user_profile_image'),
+        ("accounts", "0005_alter_user_profile_image"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='user',
-            name='profile_image',
-            field=models.ImageField(default='accounts/images/default_profile_image.png', upload_to='accounts/images'),
+            model_name="user",
+            name="profile_image",
+            field=models.ImageField(
+                default="accounts/images/default_profile_image.png",
+                upload_to="accounts/images",
+            ),
         ),
     ]

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import BaseUserManager
 from django.core.validators import MaxValueValidator, MinValueValidator
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
+from apis.serializers import GardenSerializer
 
 User = get_user_model()
 
@@ -15,6 +16,7 @@ class AuthUserSerializer(serializers.ModelSerializer):
         else:
             default_profile_image_url = "accounts/images/default_profile_image.png"
             return request.build_absolute_uri(default_profile_image_url)
+    gardens = GardenSerializer(many=True, required=False)
 
     class Meta:
         model = User
@@ -22,21 +24,21 @@ class AuthUserSerializer(serializers.ModelSerializer):
             "id",
             "nickname",
             "bio",
-            "has_garden",
+            "gardens",
             "profile_image",
             "experience",
         )
 
 
 class UserLoginSerializer(serializers.ModelSerializer):
-    email = serializers.CharField(max_length=300, required=True)
+    email = serializers.CharField(
+        max_length=300, required=True, write_only=True)
     password = serializers.CharField(
         required=True, write_only=True, trim_whitespace=False
     )
 
     auth_token = serializers.SerializerMethodField()
     id = serializers.SerializerMethodField()
-    # user = AuthUserSerializer(source='email', required=False)
 
     def get_auth_token(self, obj):
         token = Token.objects.get_or_create(user=obj)
@@ -57,23 +59,8 @@ class EmptySerializer(serializers.Serializer):
     pass
 
 
-class UserSerializer(serializers.Serializer):
-    class Meta:
-        model = User
-        fields = (
-            "id",
-            "email",
-            "password",
-            "nickname",
-            "has_garden",
-            "bio",
-            "profile_image",
-        )
-
-
 class UserRegisterSerializer(serializers.ModelSerializer):
     nickname = serializers.CharField(required=False)
-    has_garden = serializers.BooleanField(required=False)
     bio = serializers.CharField(
         style={"base_template": "textarea.html"}, required=False
     )
@@ -89,7 +76,6 @@ class UserRegisterSerializer(serializers.ModelSerializer):
             "email",
             "password",
             "nickname",
-            "has_garden",
             "bio",
             "profile_image",
             "experience",
@@ -108,7 +94,6 @@ class UserRegisterSerializer(serializers.ModelSerializer):
 
 class UserUpdateSerializer(serializers.ModelSerializer):
     nickname = serializers.CharField(required=False)
-    has_garden = serializers.BooleanField(required=False)
     bio = serializers.CharField(
         style={"base_template": "textarea.html"}, required=False
     )
@@ -116,7 +101,7 @@ class UserUpdateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ("nickname", "has_garden", "bio",
+        fields = ("nickname", "bio",
                   "profile_image", "experience")
 
 

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -4,14 +4,10 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 
-from apis.serializers import GardenSerializer
-
 User = get_user_model()
 
 
 class AuthUserSerializer(serializers.ModelSerializer):
-    gardens = GardenSerializer(many=True, required=False)
-
     def get_profile_image(self, user):
         request = self.context.get("request")
         if user.profile_image.url:
@@ -28,23 +24,19 @@ class AuthUserSerializer(serializers.ModelSerializer):
             "bio",
             "has_garden",
             "profile_image",
-            "gardens",
             "experience",
         )
 
 
-class UserLoginSerializer(serializers.Serializer):
+class UserLoginSerializer(serializers.ModelSerializer):
     email = serializers.CharField(max_length=300, required=True)
     password = serializers.CharField(
         required=True, write_only=True, trim_whitespace=False
     )
 
-    class meta:
-        model = User
-        fields = ("auth_token", "id")
-
     auth_token = serializers.SerializerMethodField()
     id = serializers.SerializerMethodField()
+    # user = AuthUserSerializer(source='email', required=False)
 
     def get_auth_token(self, obj):
         token = Token.objects.get_or_create(user=obj)
@@ -53,6 +45,12 @@ class UserLoginSerializer(serializers.Serializer):
     def get_id(self, obj):
         id = User.objects.get(email=obj.email).id
         return id
+
+    class Meta:
+        model = User
+        fields = ("id", "email", "password", "auth_token")
+        extra_kwargs = {"email": {"write_only": True},
+                        "password": {"write_only": True}}
 
 
 class EmptySerializer(serializers.Serializer):
@@ -118,7 +116,8 @@ class UserUpdateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ("nickname", "has_garden", "bio", "profile_image", "experience")
+        fields = ("nickname", "has_garden", "bio",
+                  "profile_image", "experience")
 
 
 class PasswordChangeSerializer(serializers.Serializer):
@@ -127,7 +126,8 @@ class PasswordChangeSerializer(serializers.Serializer):
 
     def validate_current_password(self, value):
         if not self.context["request"].user.check_password(value):
-            raise serializers.ValidationError("Current password does not match")
+            raise serializers.ValidationError(
+                "Current password does not match")
         return value
 
     def validate_new_password(self, value):

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -15,21 +15,24 @@ class TestRegisterUser(APITestCase):
 
     def test_can_create_account(self):
         data = UserFactory.create_user_dict(email="hellothere@test.test")
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         assert response.status_code == 201
         assert User.objects.count() == 2
         assert User.objects.get(email="hellothere@test.test")
 
     def test_should_accept_experience_from_one_to_five_on_creation(self):
         data = UserFactory.create_user_dict(experience=5)
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         json_response = json.loads(response.content)
         assert response.status_code == 201
         assert json_response["experience"] == 5
 
     def test_cannot_create_account_with_experience_greater_than_five(self):
         data = UserFactory.create_user_dict(experience=10)
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         json_response = json.loads(response.content)
         assert response.status_code == 400
         assert json_response["experience"] == [
@@ -38,7 +41,8 @@ class TestRegisterUser(APITestCase):
 
     def test_cannot_create_account_with_experience_less_than_one(self):
         data = UserFactory.create_user_dict(experience=0)
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         json_response = json.loads(response.content)
         assert response.status_code == 400
         assert json_response["experience"] == [
@@ -47,21 +51,24 @@ class TestRegisterUser(APITestCase):
 
     def test_cannot_create_account_with_experience_set_as_decimal(self):
         data = UserFactory.create_user_dict(experience=1.3)
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         json_response = json.loads(response.content)
         assert response.status_code == 400
         assert json_response["experience"] == ["A valid integer is required."]
 
     def test_cannot_create_account_with_invalid_email(self):
         data = UserFactory.create_user_dict(email="lol.l")
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         json_response = json.loads(response.content)
         assert response.status_code == 400
         assert json_response["email"] == ["Enter a valid email address."]
 
     def test_cannot_create_user_with_already_existed_email(self):
         data = UserFactory.create_user_dict(email="john@snow.com")
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         json_response = json.loads(response.content)
 
         assert response.status_code == 400
@@ -71,7 +78,8 @@ class TestRegisterUser(APITestCase):
 
     def test_cannot_create_user_with_password_less_than_8_chars(self):
         data = UserFactory.create_user_dict(password="123")
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         json_response = json.loads(response.content)
         assert response.status_code == 400
         assert json_response["password"] == [
@@ -82,7 +90,8 @@ class TestRegisterUser(APITestCase):
 
     def test_should_accept_uploaded_images_on_creation(self):
         data = UserFactory.create_user_dict(profile_image=temporary_image())
-        response = self.client.post("/api/auth/register", data, format="multipart")
+        response = self.client.post(
+            "/api/auth/register", data, format="multipart")
         assert response.status_code == 201
 
 
@@ -100,6 +109,17 @@ class TestUserLogin(APITestCase):
             HTTP_AUTHORIZATION="Token {}".format(self.token),
         )
         assert response.status_code == 200
+
+    def test_when_successfully_logged_in_returns_user_info(self):
+        data = {"email": "john@snow.com", "password": "johnpassword"}
+        response = self.client.post(
+            "/api/auth/login",
+            data,
+            format="json",
+            HTTP_AUTHORIZATION="Token {}".format(self.token),
+        )
+        json_response = json.loads(response.content)
+        assert json_response["user"]["id"] == self.user.id
 
     def test_cannot_login_with_invalid_email_or_password(self):
         data = {"email": "john@snow.com", "password": "123"}
@@ -137,7 +157,6 @@ class TestGetUserDetail(APITestCase):
         self.user2 = User.objects.create_user("hello@lol.fr", "hellofoobar")
 
     def test_can_get_user_info_by_id(self):
-        print(self.user.id)
         response = self.client.get(f"/api/users/{self.user.id}")
         json_response = json.loads(response.content)
         assert response.status_code == 200
@@ -170,7 +189,8 @@ class TestUpdateUser(APITestCase):
         self.client.force_authenticate(user=self.user)
 
         data = {"bio": "barfoo"}
-        response = self.client.put(f"/api/users/{self.user.id}", data, format="json")
+        response = self.client.put(
+            f"/api/users/{self.user.id}", data, format="json")
         json_response = json.loads(response.content)
         assert response.status_code == 200
         assert json_response["bio"] == "barfoo"

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -57,8 +57,11 @@ class AuthViewSet(viewsets.GenericViewSet):
         serializer.is_valid(raise_exception=True)
         user = get_and_authenticate_user(**serializer.validated_data)
         data = serializers.UserLoginSerializer(user).data
+        user_data = {"user": serializers.AuthUserSerializer(
+            user, context={"request": request}).data}
+        response = data | user_data
         login(request, user)
-        return Response(data=data, status=status.HTTP_200_OK)
+        return Response(data=response, status=status.HTTP_200_OK)
 
     @action(
         methods=[

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -59,7 +59,7 @@ class AuthViewSet(viewsets.GenericViewSet):
         data = serializers.UserLoginSerializer(user).data
         user_data = {"user": serializers.AuthUserSerializer(
             user, context={"request": request}).data}
-        response = data | user_data
+        response = {**data, **user_data}
         login(request, user)
         return Response(data=response, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
# ℹ️ Context

Send additional user info when the user successfully logged in. 
Example: 
```
{
    "id": 20,
    "email": "helloWorld@image.fr",
    "auth_token": "token",
    "user": {
        "id": 20,
        "nickname": "hello",
        "bio": null,
        "has_garden": false,
        "profile_image": "http://127.0.0.1:8000/accounts/images/default_profile_image.png",
        "experience": 1
    }
}
```

## ❓ Type of change

* ✨ New feature (non-breaking change which adds functionality)
