### PR TITLE
feat: add user delete endpoint for testing only

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -142,3 +142,9 @@ class UserViewSet(viewsets.ViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         else:
             raise ValidationError("You can only edit your own profile.")
+
+    def delete(self, request, pk=None):
+        user = get_object_or_404(self.queryset, pk=pk)
+        if user:
+            user.delete()
+        return Response(status=status.HTTP_200_OK)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -112,7 +112,7 @@ class UserViewSet(viewsets.ViewSet):
     queryset = User.objects.all()
 
     def get_permissions(self):
-        if self.action == "update":
+        if self.action == "update" or self.action == "delete":
             permission_classes = [IsAuthenticated]
         else:
             permission_classes = [AllowAny]


### PR DESCRIPTION
# ℹ️ Context

The delete endpoint is currently only for cypress test only. 
It needs to be refined for further usage.

The endpoint:
`/api/users/:id`

## ❓ Type of change

* ✨ New feature (non-breaking change which adds functionality)

